### PR TITLE
WIP: Update Spring Boot 1.5.x to 2.7.x - Phase 1 Property Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.3.RELEASE</version>
+        <version>2.7.18</version>
         <relativePath />
     </parent>
 
@@ -40,13 +40,13 @@
         <akka.slf4j>2.5.1</akka.slf4j>
         <hikari.cp.version>2.6.1</hikari.cp.version>
         <jackson.module.kotlin.version>2.9.3</jackson.module.kotlin.version>
-        <kotlin.version>1.2.50</kotlin.version>
+        <kotlin.version>1.7.22</kotlin.version>
         <liquibase.core.version>3.5.3</liquibase.core.version>
         <liquibase.version>1.2.4</liquibase.version>
         <log4j.version>2.17.1</log4j.version>
         <postgresql.version>42.2.2</postgresql.version>
         <realwave.graylog.version>1.1.6</realwave.graylog.version>
-        <spring.boot.version>1.5.3.RELEASE</spring.boot.version>
+        <spring.boot.version>2.7.18</spring.boot.version>
         <spring.restdocs.version>1.2.1.RELEASE</spring.restdocs.version>
         <realwave.exception.handler.version>1.0.8</realwave.exception.handler.version>
         <zup.spring.tenant.version>1.1.3</zup.spring.tenant.version>
@@ -62,7 +62,7 @@
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <hibernate.validator.version>5.3.5.Final</hibernate.validator.version>
         <javax.anotation.api.version>1.2</javax.anotation.api.version>
-        <spring.cloud.version>Edgware.RELEASE</spring.cloud.version>
+        <spring.cloud.version>2021.0.9</spring.cloud.version>
         <jacoco.maven.plugin.version>0.7.9</jacoco.maven.plugin.version>
         <realwave.rw.coupon.api.version>2017R4.3.0</realwave.rw.coupon.api.version>
         <realwave.pcm.client.version>2018R1.0.22</realwave.pcm.client.version>
@@ -150,6 +150,12 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>${javax.anotation.api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-properties-migrator</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/realwave-sales-manager-api/pom.xml
+++ b/realwave-sales-manager-api/pom.xml
@@ -23,6 +23,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate.validator.version}</version>
         </dependency>
 
         <!-- Tests -->
@@ -56,12 +57,6 @@
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-netflix-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/realwave-sales-manager-command-application/src/main/resources/application.properties
+++ b/realwave-sales-manager-command-application/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.contextPath=/
+server.servlet.context-path=/
 server.port=8080
 
 graylog.server=realwave-dev-graylog01.local.zup.com.br
@@ -29,8 +29,6 @@ keycloak.bearerOnly=true
 keycloak.sslRequired=external
 
 # Security
-security.enabled=true
-security.basic.enabled=false
 security.corsEnabled=false
 security.permitUnmappedResources=true
 security.tokenCompressionEnabled=true
@@ -65,10 +63,8 @@ com.callback.url=http://localhost:8080/purchase-orders/callback
 external.module=sales-manager
 
 # Actuator
-endpoints.sensitive=false
-management.security.enabled=true
-management.security.roles=monitoring
-management.context-path=/manage
+management.endpoint.health.show-details=when-authorized
+management.endpoints.web.base-path=/manage
 
 # Kafka
 kafka.topic.rw.sales.manager.events=rw_sm_purchase_events

--- a/realwave-sales-manager-command-application/src/main/resources/bootstrap.properties
+++ b/realwave-sales-manager-command-application/src/main/resources/bootstrap.properties
@@ -4,7 +4,7 @@ spring.cloud.config.enabled=false
 spring.cloud.consul.port=8500
 spring.cloud.consul.config.fail-fast=true
 spring.cloud.consul.config.format=properties
-spring.cloud.consul.discovery.healthCheckPath=${server.contextPath:"/"}${management.context-path:""}/health
-spring.cloud.consul.discovery.tags=management.context-path=${management.context-path}
+spring.cloud.consul.discovery.healthCheckPath=${server.servlet.context-path:/}${management.endpoints.web.base-path:}/health
+spring.cloud.consul.discovery.tags=management.endpoints.web.base-path=${management.endpoints.web.base-path}
 
 management.health.consul.enabled=false

--- a/realwave-sales-manager-consumer/src/main/resources/application.properties
+++ b/realwave-sales-manager-consumer/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.profiles.active=postgresql
-server.contextPath=/
+server.servlet.context-path=/
 server.port=8082
 
 # Graylog
@@ -44,8 +44,6 @@ keycloak.sslRequired=external
 keycloak.credentials.secret=6bbf2c19-86af-4dc7-ae8f-4fe111bd95a8
 
 # Security
-security.enabled=true
-security.basic.enabled=false
 security.corsEnabled=false
 security.permitUnmappedResources=true
 security.tokenCompressionEnabled=true
@@ -75,9 +73,7 @@ spring.kafka.listener.concurrency=2
 spring.kafka.consumer.auto-offset-reset=latest
 
 # Actuator
-management.security.enabled=true
-management.security.roles=monitoring
-management.context-path=/manage
+management.endpoints.web.base-path=/manage
 
 # Topics
 kafka.topic.rw.sales.manager.events=rw_sm_purchase_events

--- a/realwave-sales-manager-consumer/src/main/resources/bootstrap.properties
+++ b/realwave-sales-manager-consumer/src/main/resources/bootstrap.properties
@@ -4,7 +4,7 @@ spring.cloud.config.enabled=false
 spring.cloud.consul.port=8500
 spring.cloud.consul.config.fail-fast=true
 spring.cloud.consul.config.format=properties
-spring.cloud.consul.discovery.healthCheckPath=${server.contextPath:"/"}${management.context-path:""}/health
-spring.cloud.consul.discovery.tags=management.context-path=${management.context-path}
+spring.cloud.consul.discovery.healthCheckPath=${server.servlet.context-path:/}${management.endpoints.web.base-path:}/health
+spring.cloud.consul.discovery.tags=management.endpoints.web.base-path=${management.endpoints.web.base-path}
 
 management.health.consul.enabled=false

--- a/realwave-sales-manager-integration/src/test/resources/application.properties
+++ b/realwave-sales-manager-integration/src/test/resources/application.properties
@@ -1,6 +1,3 @@
 spring.profiles.active=test
 com.callback.url=http://sales-manager/callbacks
 external.module=sales-manager
-
-security.enabled=false
-security.basic.enabled=false

--- a/realwave-sales-manager-query-application/src/main/resources/application.properties
+++ b/realwave-sales-manager-query-application/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.profiles.active=postgresql
 
-server.contextPath=/
+server.servlet.context-path=/
 server.port=8180
 
 spring.jackson.default-property-inclusion=non_null
@@ -28,8 +28,6 @@ keycloak.bearerOnly=true
 keycloak.sslRequired=external
 
 # Security
-security.enabled=true
-security.basic.enabled=false
 security.corsEnabled=false
 security.permitUnmappedResources=true
 security.tokenCompressionEnabled=true
@@ -69,7 +67,5 @@ persistent.subscription.max.backoff=30
 persistent.subscription.random.factor=0.2
 
 # Actuator
-endpoints.sensitive=false
-management.security.enabled=true
-management.security.roles=monitoring
-management.context-path=/manage
+management.endpoint.health.show-details=when-authorized
+management.endpoints.web.base-path=/manage

--- a/realwave-sales-manager-query-application/src/main/resources/bootstrap.properties
+++ b/realwave-sales-manager-query-application/src/main/resources/bootstrap.properties
@@ -4,6 +4,6 @@ spring.cloud.config.enabled=false
 spring.cloud.consul.port=8500
 spring.cloud.consul.config.fail-fast=true
 spring.cloud.consul.config.format=properties
-spring.cloud.consul.discovery.healthCheckPath=${server.contextPath:"/"}${management.context-path:""}/health
-spring.cloud.consul.discovery.tags=management.context-path=${management.context-path}
+spring.cloud.consul.discovery.healthCheckPath=${server.servlet.context-path:/}${management.endpoints.web.base-path:}/health
+spring.cloud.consul.discovery.tags=management.endpoints.web.base-path=${management.endpoints.web.base-path}
 


### PR DESCRIPTION
This commit includes the initial steps of upgrading Spring Boot from 1.5.3.RELEASE to 2.7.18 and Spring Cloud from Edgware.RELEASE to 2021.0.9.

So far, I have taken the following actions:

1.  **Updated Parent POM:**
    *   I updated the `spring-boot-starter-parent` version to `2.7.18`.
    *   I updated the `spring.boot.version` property to `2.7.18`.
    *   I updated the `spring.cloud.version` property to `2021.0.9`.
    *   I updated the `kotlin.version` property to `1.7.22`.
    *   I added `spring-boot-properties-migrator` as a temporary runtime dependency to help identify deprecated properties.

2.  **Configuration Property Changes (based on Spring Boot 2.0 Migration Guide):**
    *   I updated `server.contextPath` to `server.servlet.context-path` in:
        *   `realwave-sales-manager-command-application/src/main/resources/application.properties`
        *   `realwave-sales-manager-query-application/src/main/resources/application.properties`
        *   `realwave-sales-manager-consumer/src/main/resources/application.properties`
    *   I removed deprecated security properties (`security.enabled`, `security.basic.enabled`) from:
        *   The three application modules listed above.
        *   `realwave-sales-manager-integration/src/test/resources/application.properties`
    *   I updated Actuator properties:
        *   `endpoints.sensitive=false` to `management.endpoint.health.show-details=when-authorized` (in command and query applications).
        *   I removed `management.security.enabled=true` and `management.security.roles=monitoring` (in all three application modules).
        *   `management.context-path=/manage` to `management.endpoints.web.base-path=/manage` (in all three application modules).
    *   I updated Spring Cloud Consul properties in `bootstrap.properties` for all three application modules:
        *   `spring.cloud.consul.discovery.healthCheckPath` to use new servlet context and management base path properties.
        *   `spring.cloud.consul.discovery.tags` to use new management base path property.

**Current Status & Next Steps:**

The project build is currently blocked due to a Maven authentication error when trying to download a private dependency (`realwave-graylog`). This prevents further automated analysis (like compiler errors or output from the properties migrator).

The next steps I planned, which I could not start due to the build blockage, would involve:
*   Resolving the build authentication issue.
*   Running a Maven build to identify compilation errors and further property migration needs.
*   Systematically addressing code changes based on migration guides (e.g., package changes for embedded containers, `RelaxedPropertyResolver` replacement, `@ConfigurationProperties` validation, `RestTemplateBuilder` updates).
*   Addressing Liquibase property naming (`liquibase.changeLog` to `spring.liquibase.change-log`, etc.).
*   Updating dependencies (Spring modules, third-party libraries) and testing.

This commit captures the property changes I've made so far based on manual inspection of the Spring Boot 2.0 migration guide.

# Description

any description

**Story or Task:**
* [RWAVE-XYZ](http://www.google.com)

**What has changed?**

* New resource POST /test

* New payload:

```json
{
    "test": {
        "type": "TEST"
    }
}
```

* Update kotlin to version [1.2.50](https://search.maven.org/#artifactdetails%7Corg.jetbrains.kotlin%7Ckotlin-stdlib-jdk8%7C1.2.50%7Cjar)

# Script to change

**Dependencies**
* [2018RX.Y.Z](http://www.google.com) - UI
* [2018RX.Y.Z](http://www.google.com) - Customer Order Manager

**Steps:**
1 - Deploy no gateway da versão v1-32
2 - Certificar que a aplicação está UP no Spring Boot Admin
3 - Executar via POST a url http://algumacoisa.dev/update-reward